### PR TITLE
Remove docker driver code pulling images

### DIFF
--- a/driver/docker.go
+++ b/driver/docker.go
@@ -96,23 +96,12 @@ func (d *DockerDriver) Create(name, image string, detached bool, trace bool) (Co
 	return newDockerContainer(name, image, detached, trace), nil
 }
 
-// Clean will clean the environment; removing any remaining containers in the runc metadata
+// Clean will clean the environment; removing any exited containers
 func (d *DockerDriver) Clean() error {
-	// make sure some default images are pulled
-	log.Info("Pulling busybox image")
-	out, err := utils.ExecCmd(d.dockerBinary, "pull busybox")
-	if err != nil {
-		return fmt.Errorf("Can't pull busybox image: %v (output: %s)", err, out)
-	}
-	log.Info("Pulling redis image")
-	out, err = utils.ExecCmd(d.dockerBinary, "pull redis")
-	if err != nil {
-		return fmt.Errorf("Can't pull redis image: %v (output: %s)", err, out)
-	}
 	// clean up any containers from a prior run
 	log.Info("Clearing docker daemon exited containers")
 	cmd := "docker rm -f `docker ps -aq`"
-	out, err = utils.ExecCmd("bash", "-c "+cmd)
+	out, err := utils.ExecCmd("bash", "-c "+cmd)
 	if err != nil {
 		log.Warnf("Couldn't clean up docker daemon containers: %v (output: %s)", err, out)
 	}


### PR DESCRIPTION
The `Validate()` function will now try to run the specified container
before the benchmark starts, making sure that there are no pull times
logged during the benchmark run.  Also, the busybox and redis pulls are
vestigial remains of a hardcoded test that relied on those two images.

Signed-off-by: Phil Estes <estesp@gmail.com>