### PR TITLE
Add Go 1.8 version to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@
   language: go
   sudo: false
   go:
-    - 1.7
+    - 1.7.x
+    - 1.8.x
+    - tip
   install:
     - go get github.com/golang/lint/golint
   script:


### PR DESCRIPTION
Add Go 1.8 and update config to use latest release (instead of ".0") for
1.7 and 1.8 as well as adding "tip" to configuration.

Signed-off-by: Phil Estes <estesp@gmail.com>