### PR TITLE
Fix the docker driver cleanup routine

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -53,3 +53,11 @@ func ExecCmd(cmd, args string) (string, error) {
 	out, err := execCmd.CombinedOutput()
 	return string(out), err
 }
+
+// ExecShellCmd executes a 'bash -c' process, with the passed-in command
+// handed to the -c flag of bash
+func ExecShellCmd(cmd string) (string, error) {
+	execCmd := exec.Command("bash", "-c", cmd)
+	out, err := execCmd.CombinedOutput()
+	return string(out), err
+}


### PR DESCRIPTION
Was incorrectly not handling running containers as well as filtering to
only handle containers instantiated via the bucketbench driver.

Signed-off-by: Phil Estes <estesp@gmail.com>