### PR TITLE
Fixup IO setup on containerd Run()

### DIFF
--- a/benches/custom.go
+++ b/benches/custom.go
@@ -102,6 +102,10 @@ func (cb *CustomBench) Run(threads, iterations int, commands []string) error {
 		}
 	}
 	cb.state = Completed
+	// final environment cleanup
+	if err := cb.driver.Clean(); err != nil {
+		return fmt.Errorf("Error during driver final cleanup: %v", err)
+	}
 	return nil
 }
 

--- a/examples/ctrd.yaml
+++ b/examples/ctrd.yaml
@@ -1,5 +1,5 @@
 name: CtrdRunOnly
-image: busybox
+image: alpine
 command: date
 detached: true
 drivers:


### PR DESCRIPTION
Capture stdout/err like the other drivers and return. Also remove some
debug output and add final driver.Clean() after end of benchmark runs.

Signed-off-by: Phil Estes <estesp@gmail.com>