### PR TITLE
More cleanup to containerd driver and examples

### DIFF
--- a/driver/containerd_ctr.go
+++ b/driver/containerd_ctr.go
@@ -95,6 +95,17 @@ func (r *CtrDriver) Type() Type {
 	return Ctr
 }
 
+// Path returns the binary path of the ctr binary in use
+func (r *CtrDriver) Path() string {
+	return r.ctrBinary
+}
+
+// Close allows the driver to handle any resource free/connection closing
+// as necessary. Ctr has no need to perform any actions on close.
+func (r *CtrDriver) Close() error {
+	return nil
+}
+
 // Info returns
 func (r *CtrDriver) Info() (string, error) {
 	info := "containerd legacy driver (ctr client binary: " + r.ctrBinary + ")"

--- a/driver/docker.go
+++ b/driver/docker.go
@@ -87,6 +87,17 @@ func (d *DockerDriver) Type() Type {
 	return Docker
 }
 
+// Path returns the binary path of the docker binary in use
+func (d *DockerDriver) Path() string {
+	return d.dockerBinary
+}
+
+// Close allows the driver to handle any resource free/connection closing
+// as necessary. Docker has no need to perform any actions on close.
+func (d *DockerDriver) Close() error {
+	return nil
+}
+
 // Info returns
 func (d *DockerDriver) Info() (string, error) {
 	if d.dockerInfo != "" {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -52,6 +52,9 @@ type Driver interface {
 	// Info returns a string with information about the container engine/runtime details
 	Info() (string, error)
 
+	// Path returns the binary (or socket) path related to the runtime in use
+	Path() string
+
 	// Create will create a container instance matching the specific needs
 	// of a driver
 	Create(name, image, cmdOverride string, detached bool, trace bool) (Container, error)
@@ -73,6 +76,10 @@ type Driver interface {
 
 	// Unpause will unpause/resume a container
 	Unpause(ctr Container) (string, int, error)
+
+	// Close allows the driver to free any resources/close any
+	// connections
+	Close() error
 }
 
 // New creates a driver instance of a specific type

--- a/driver/runc.go
+++ b/driver/runc.go
@@ -96,6 +96,17 @@ func (r *RuncDriver) Type() Type {
 	return Runc
 }
 
+// Path returns the binary path of the runc binary in use
+func (r *RuncDriver) Path() string {
+	return r.runcBinary
+}
+
+// Close allows the driver to handle any resource free/connection closing
+// as necessary. Runc has no need to perform any actions on close.
+func (r *RuncDriver) Close() error {
+	return nil
+}
+
 // Info returns
 func (r *RuncDriver) Info() (string, error) {
 	info := "runc driver (binary: " + r.runcBinary + ")\n"

--- a/examples/ctrd-run.yaml
+++ b/examples/ctrd-run.yaml
@@ -1,4 +1,4 @@
-name: CtrdOnly
+name: CtrdRunOnly
 image: alpine
 command: date
 detached: true
@@ -6,8 +6,6 @@ drivers:
   - 
    type: Containerd
    threads: 5
-   iterations: 10
+   iterations: 50
 commands:
   - run
-  - stop
-  - delete


### PR DESCRIPTION
Several cleanups to containerd driver/interactions:
 - use per-thread client connection (via driver object creation)
 - close driver so client closes after each thread completes
 - fix example yaml to have a stop for run, stop, delete ordering
 - wait on task stop correctly

Signed-off-by: Phil Estes <estesp@gmail.com>