### PR TITLE
Fix panic when "Limit" is run during detailed stats output

### DIFF
--- a/benches/custom.go
+++ b/benches/custom.go
@@ -132,38 +132,38 @@ func (cb *CustomBench) runThread(driver driver.Driver, threadNum, iterations int
 			case "run", "start":
 				out, runElapsed, err := driver.Run(ctr)
 				if err != nil {
-					errors[cmd]++
+					errors["run"]++
 					log.Warnf("Error during container command %q on %q: %v\n  Output: %s", cmd, name, err, out)
 				}
-				durations[cmd] = runElapsed
+				durations["run"] = runElapsed
 			case "stop", "kill":
 				out, stopElapsed, err := driver.Stop(ctr)
 				if err != nil {
-					errors[cmd]++
+					errors["stop"]++
 					log.Warnf("Error during container command %q on %q: %v\n  Output: %s", cmd, name, err, out)
 				}
-				durations[cmd] = stopElapsed
+				durations["stop"] = stopElapsed
 			case "remove", "erase", "delete":
 				out, rmElapsed, err := driver.Remove(ctr)
 				if err != nil {
-					errors[cmd]++
+					errors["delete"]++
 					log.Warnf("Error during container command %q on %q: %v\n  Output: %s", cmd, name, err, out)
 				}
-				durations[cmd] = rmElapsed
+				durations["delete"] = rmElapsed
 			case "pause":
 				out, pauseElapsed, err := driver.Pause(ctr)
 				if err != nil {
-					errors[cmd]++
+					errors["pause"]++
 					log.Warnf("Error during container command %q on %q: %v\n  Output: %s", cmd, name, err, out)
 				}
-				durations[cmd] = pauseElapsed
+				durations["pause"] = pauseElapsed
 			case "unpause", "resume":
 				out, unpauseElapsed, err := driver.Unpause(ctr)
 				if err != nil {
-					errors[cmd]++
+					errors["resume"]++
 					log.Warnf("Error during container command %q on %q: %v\n  Output: %s", cmd, name, err, out)
 				}
-				durations[cmd] = unpauseElapsed
+				durations["resume"] = unpauseElapsed
 			default:
 				log.Errorf("Command %q unrecognized from YAML commands list; skipping", cmd)
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -189,14 +189,24 @@ func outputRunDetails(maxThreads int, results []benchResult) {
 	w.Flush()
 	fmt.Println("")
 
+	cmdList := []string{"run", "pause", "resume", "stop", "delete"}
 	fmt.Printf("DETAILED COMMAND TIMINGS/STATISTICS\n")
 	// output per-command timings across the runs as well
 	for _, result := range results {
+		if result.name == "Limit" {
+			// the limit "benchmark" has no detailed statistics
+			continue
+		}
 		for i := 0; i < result.threads; i++ {
 			fmt.Fprintf(w, "%s:%d\tMin\tMax\tAvg\tMedian\tStddev\tErrors\t\n", result.name, i+1)
 			cmdTimings := parseStats(result.statistics[i])
-			for cmd, stats := range cmdTimings {
-				fmt.Fprintf(w, "%s\t%6.2f\t%6.2f\t%6.2f\t%6.2f\t%6.2f\t%d\t\n", cmd, stats.min, stats.max, stats.avg, stats.median, stats.stddev, stats.errors)
+			// given we are working with a map, but we want consistent ordering in the output
+			// we walk a slice of commands in a natural/expected order and output stats for
+			// those that were used during the specific run
+			for _, cmd := range cmdList {
+				if stats, ok := cmdTimings[cmd]; ok {
+					fmt.Fprintf(w, "%s\t%6.2f\t%6.2f\t%6.2f\t%6.2f\t%6.2f\t%d\t\n", cmd, stats.min, stats.max, stats.avg, stats.median, stats.stddev, stats.errors)
+				}
 			}
 		}
 		fmt.Println("")


### PR DESCRIPTION
Fixes: #24 

When "Limit" is not skipped, we need to skip it during detailed output
as it has no statistics to display. Also, enforce natural ordering on
the output for easy comparison. This required standardizing lifecycle
operation names stored for output, even though we accept several
synonyms in the benchmark definition.

Signed-off-by: Phil Estes <estesp@gmail.com>