### PR TITLE
Remove 'tip' testing; update to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@
   language: go
   sudo: false
   go:
-    - 1.8.x
-    - tip
+    - 1.9.x
   install:
     - go get github.com/golang/lint/golint
   script:


### PR DESCRIPTION
Update travis config to remove testing of "tip" and update main Golang
version to 1.9.x

Signed-off-by: Phil Estes <estesp@gmail.com>