### PR TITLE
Add version command and simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: all binary static clean install
+
+PREFIX ?= ${DESTDIR}/usr
+INSTALLDIR=${PREFIX}/bin
+MANINSTALLDIR=${PREFIX}/share/man
+
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
+
+all: binary
+
+# Target to build a dynamically linked binary
+binary:
+	go build -ldflags "-X github.com/estesp/bucketbench/cmd.gitCommit=${COMMIT}" -o bucketbench github.com/estesp/bucketbench
+
+# Target to build a statically linked binary
+static:
+	GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 go build \
+	   -ldflags "-w -extldflags -static -X github.com/estesp/bucketbench/cmd.gitCommit=${COMMIT}" \
+	   -tags netgo -installsuffix netgo \
+	   -o bucketbench github.com/estesp/bucketbench
+
+clean:
+	rm -f bucketbench
+
+install:
+	install -d -m 0755 ${INSTALLDIR}
+	install -m 755 bucketbench ${INSTALLDIR}

--- a/README.md
+++ b/README.md
@@ -144,9 +144,13 @@ It will most likely build for other platforms, and if run against a tool like
 Docker for Mac, would probably work against the Docker engine, but not
 against `containerd` or `runc`.
 
-All the necessary dependencies are vendored into the `bucketbench` tree, so
-building should be as easy as `go build -o bucketbench .` Using `go install github.com/estesp/bucketbench`
-should work as well.
+All the necessary dependencies are vendored into the `bucketbench` source tree.
+Building `bucketbench` only requires that you have a valid Golang build/runtime
+environment. Any recent release of Go will work, but it is currently building
+with Go 1.9.x and 1.10. A simple `Makefile` is available to simplify building
+bucketbench as a dynamic or static binary. `make binary` will build the
+`bucketbench` binary and `make install` will place it in your `$PATH`. You
+should also be able to simply `go install github.com/estesp/bucketbench`.
 
 ## TODOs
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,40 @@
+// Copyright © 2018 Phil Estes <estesp@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// filled in at compile time
+var gitCommit = ""
+
+const version = "0.4.0"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display bucketbench version and git commit information.",
+	Long: `Display the bucketbench version and git commit information embedded in
+the binary at build time.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("bucketbench v%s (commit: %s)\n", version, gitCommit)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Add a `bucketbench version` command with a hardcoded version and compile-time git commit.

Adds a simple `Makefile` for ease of building `bucketbench` given a reasonable Golang build environment.