### PR TITLE
Use Makefile; add Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@
   sudo: false
   go:
     - 1.9.x
+    - 1.10.x
   install:
     - go get github.com/golang/lint/golint
   script:
-    - go build -v
+    - make binary
     - go vet $(go list ./... | grep -v vendor)
     - test -z "$(golint ./... | grep -v vendor | tee /dev/stderr)"
     - test -z "$(gofmt -s -l . | grep -v vendor | tee /dev/stderr)"


### PR DESCRIPTION
Update travis config to use the Makefile and add Golang 1.10 as a build
target.

Signed-off-by: Phil Estes <estesp@gmail.com>