### PR TITLE
driver: use stop instead of kill in DockerCLI

### DIFF
--- a/driver/docker_cli.go
+++ b/driver/docker_cli.go
@@ -213,9 +213,9 @@ func (d *DockerCLIDriver) Run(ctx context.Context, ctr Container) (string, time.
 	return utils.ExecTimedCmd(ctx, d.dockerBinary, strings.Join(args, " "))
 }
 
-// Stop will stop/kill a container
+// Stop will stop a container
 func (d *DockerCLIDriver) Stop(ctx context.Context, ctr Container) (string, time.Duration, error) {
-	return utils.ExecTimedCmd(ctx, d.dockerBinary, "kill "+ctr.Name())
+	return utils.ExecTimedCmd(ctx, d.dockerBinary, "stop "+ctr.Name())
 }
 
 // Remove will remove a container


### PR DESCRIPTION
The Docker driver uses the `stop` API. In order to align with Docker
drvier, DockerCLI should use `stop` command instead of `kill`.

Signed-off-by: Wei Fu <fuweid89@gmail.com>