### PR TITLE
Use Go modules in addition of vendor.conf for newer Go's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,40 @@
+module github.com/estesp/bucketbench
+
+go 1.12
+
+require (
+	github.com/containerd/cgroups v0.0.0-20190328223300-4994991857f9
+	github.com/containerd/containerd v1.2.6
+	github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352
+	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260
+	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
+	github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b
+	github.com/docker/distribution v0.0.0-20190205005809-0d3efadf0154
+	github.com/docker/docker v0.0.0-20171019062838-86f080cff091
+	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad
+	github.com/docker/go-units v0.4.0
+	github.com/go-yaml/yaml v0.0.0-20190319135612-7b8349ac747c
+	github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55
+	github.com/gogo/googleapis v1.0.0
+	github.com/gogo/protobuf v1.0.0
+	github.com/golang/protobuf v1.1.0
+	github.com/montanaflynn/stats v0.0.0-20170404204349-41c34e4914ec
+	github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2
+	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/runc v0.0.0-20190403200919-029124da7af7
+	github.com/opencontainers/runtime-spec v0.0.0-20190207185410-29686dbc5559
+	github.com/pkg/errors v0.8.1
+	github.com/shirou/gopsutil v0.0.0-20180916084002-77e5abb6f06f
+	github.com/sirupsen/logrus v1.0.1
+	github.com/spf13/cobra v0.0.0-20170607060748-99ff9334bda2
+	github.com/spf13/pflag v1.0.0
+	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+	golang.org/x/net v0.0.0-20170716174642-b3756b4b77d7
+	golang.org/x/sync v0.0.0-20161206014632-450f422ab23c
+	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952
+	golang.org/x/text v0.0.0-20170512150324-19e51611da83
+	google.golang.org/genproto v0.0.0-20170523043604-d80a6e20e776
+	google.golang.org/grpc v1.12.0
+	k8s.io/kubernetes v1.14.1
+)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad
 	github.com/docker/go-units v0.4.0
-	github.com/go-yaml/yaml v0.0.0-20190319135612-7b8349ac747c
+	gopkg.in/yaml.v2 v0.0.0-20190319135612-7b8349ac747c
 	github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55
 	github.com/gogo/googleapis v1.0.0
 	github.com/gogo/protobuf v1.0.0


### PR DESCRIPTION
Thanks for making bucketbench!

Could you include go.mod in addition to existing vendor.conf. That would make using this tool with newer Go's easier.