### PR TITLE
cri doesn't have a standalone binary anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ against each engine.
 #### Driver Configuration
 
 Each driver has the following settings:
- - **type**: One of the four implemented drivers: `Runc`, `Docker`, `Containerd`, `Ctr`
+ - **type**: One of the six implemented drivers: `Runc`, `Docker`, `DockerCLI`, `Containerd`, `Ctr` and `CRI`
  - **clientpath**: *[Optional]* Path to the binary for client executable based drivers. In the case of containerd 1.0 and the CRI driver, this will be the unique UNIX socket path of the gRPC server. For client binary-based drivers, the driver will default to the standard binary name found in the current `$PATH`
  - **threads**: Integer number of concurrent threads to run. The `bucketbench` method is to execute 1..n runs, where `n` is the number of threads and each run adds another concurrent thread. **Run 1** only has one thread and **Run N** will have `n` concurrent threads.
  - **iterations**: Number of containers to create in each thread and execute the listed commands against.
- - **logDriver**: `Docker` and `DockerCLI` support log driver configuration to measure overhead between different implementations. Allowed values can be found [here](https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers).
+ - **procNames**: *[`CRI` only]* List of process names
+ - **logDriver**: *[`Docker` and `DockerCLI` only]* Log driver configuration to measure overhead between different implementations. Allowed values can be found [here](https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers).
  - **logOpts**: Logger driver configuration, only used with `logDriver` option. See `overhead-logdriver.yaml` for examples.
  - **streamStats**: Allows to explore the overhead of `stats` queries for different drivers. Note that `docker` driver supports streaming natively while `containerd` supports direct API calls only, so you might want to send multiple queries to emulate streaming behavior (see **statsIntervalSec**)
  - **statsIntervalSec**: Defines an interval in seconds between `stats` queries to emulate streaming behaviour for `containerd`

--- a/benches/bench.go
+++ b/benches/bench.go
@@ -49,6 +49,7 @@ type DriverConfig struct {
 	CGroupPath       string            `yaml:"cgroupPath"`
 	StreamStats      bool              `yaml:"streamStats"`
 	StatsIntervalSec int               `yaml:"statsIntervalSec"`
+	ProcNames        []string          `yaml:"procNames"`
 }
 
 // State constants

--- a/driver/common.go
+++ b/driver/common.go
@@ -118,6 +118,7 @@ type Config struct {
 	LogOpts       map[string]string
 	StreamStats   bool
 	StatsInterval time.Duration
+	ProcNames     []string
 }
 
 // New creates a driver instance of a specific type
@@ -134,7 +135,7 @@ func New(ctx context.Context, config *Config) (Driver, error) {
 	case Ctr:
 		return NewCtrDriver(config.Path)
 	case CRI:
-		return NewCRIDriver(config.Path)
+		return NewCRIDriver(config)
 	case Null:
 		return nil, nil
 	default:

--- a/driver/cri.go
+++ b/driver/cri.go
@@ -314,7 +314,7 @@ func (c *CRIDriver) Stats(ctx context.Context, ctr Container) (io.ReadCloser, er
 
 // ProcNames returns the list of process names contributing to mem/cpu usage during overhead benchmark
 func (c *CRIDriver) ProcNames() []string {
-	return []string{}
+	return containerdProcNames
 }
 
 func openFile(path string) (*os.File, error) {


### PR DESCRIPTION
Since cri is implemented as a containerd plugin, checking containerd
processes would be fine as a way to measure cri's overhead compared to
other high-level runtimes.