### PR TITLE
Fix CRI/cri-o operation with bucketbench

### DIFF
--- a/contrib/container_config.json
+++ b/contrib/container_config.json
@@ -4,7 +4,7 @@
 		"attempt": 1
 	},
 	"image": {
-		"image": "alpine:latest"
+		"image": "docker.io/library/alpine:latest"
 	},
 	"command": [
 		"/bin/ls"

--- a/driver/cri.go
+++ b/driver/cri.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultPodImage        = "gcr.io/google_containers/pause:3.0"
+	defaultPodImage        = "k8s.gcr.io/pause:3.1"
 	defaultPodNamePrefix   = "pod"
 	defaultSandboxConfig   = "contrib/sandbox_config.json"
 	defaultContainerConfig = "contrib/container_config.json"

--- a/examples/crio.yaml
+++ b/examples/crio.yaml
@@ -1,5 +1,5 @@
 name: CRICrio
-image: alpine
+image: docker.io/library/alpine:latest
 detached: true
 drivers:
   - 


### PR DESCRIPTION
Need specific image references. Fixes #45 

Note that the only change I needed to make on Ubuntu 18.04 LTS was to change the cgroup driver to "cgroupfs" from "systemd" in `/etc/crio/crio.conf`; start crio (daemon), and then run bucketbench with this PR and the `examples/crio.yaml` and I had a successful run.

This was using cri-o 1.15.x from the Ubuntu PPA.

Signed-off-by: Phil Estes <estesp@gmail.com>